### PR TITLE
Add IsMenuShown to BlazorContextMenuService

### DIFF
--- a/BlazorContextMenu.sln
+++ b/BlazorContextMenu.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		build-demo-app.bat = build-demo-app.bat
 		build.bat = build.bat
+		global.json = global.json
 		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection

--- a/BlazorContextMenu/Services/BlazorContextMenuService.cs
+++ b/BlazorContextMenu/Services/BlazorContextMenuService.cs
@@ -1,8 +1,6 @@
 ﻿using BlazorContextMenu.Services;
 using Microsoft.JSInterop;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace BlazorContextMenu
@@ -34,6 +32,11 @@ namespace BlazorContextMenu
         /// <param name="data">Extra data that will be passed to menu events.</param>
         /// <returns></returns>
         Task ShowMenu(string id, int x, int y, object data);
+
+        /// <summary>Determines if a <see cref="ContextMenu" /> is already being shown.</summary>
+        /// <param name="id">The id of the <see cref="ContextMenu"/>.</param>
+        /// <returns>True if the <see cref="ContextMenu" /> is being shown, otherwise False.</returns>
+        Task<bool> IsMenuShown(string id);
     }
 
     public class BlazorContextMenuService : IBlazorContextMenuService
@@ -72,5 +75,7 @@ namespace BlazorContextMenu
         {
             return ShowMenu(id, x, y, null);
         }
+
+        public async Task<bool> IsMenuShown(string id) => await _jSRuntime.InvokeAsync<bool>("blazorContextMenu.IsMenuShown", id);
     }
 }

--- a/BlazorContextMenu/wwwroot/blazorContextMenu.js
+++ b/BlazorContextMenu/wwwroot/blazorContextMenu.js
@@ -205,6 +205,15 @@ var blazorContextMenu = function (blazorContextMenu) {
         });
     }
 
+    blazorContextMenu.IsMenuShown = function (menuId) {
+        var menuElement = document.getElementById(menuId);
+        var instanceId = menuElement.dataset["instanceId"];
+        var menu = openMenus.find(function (item) {
+            return item.instanceId == instanceId;
+        });
+        return typeof(menu) != 'undefined' && menu != null;
+    }
+
     var subMenuTimeout = null;
     blazorContextMenu.OnMenuItemMouseOver = function (e, xOffset, currentItemElement) {
         if (closest(e.target, ".blazor-context-menu__wrapper") != closest(currentItemElement, ".blazor-context-menu__wrapper")) {

--- a/TestApps/BlazorContextMenu.TestAppsCommon/CommonIndex.razor
+++ b/TestApps/BlazorContextMenu.TestAppsCommon/CommonIndex.razor
@@ -80,6 +80,9 @@
     <p id="ignoreThis">Ignore this</p>
 </ContextMenuTrigger>
 
+<ContextMenuTrigger MenuId="menu7" MouseButtonTrigger="MouseButtonTrigger.Left">
+    <p id="menu7-test1-trigger">Left-click me (menu7)</p>
+</ContextMenuTrigger>
 
 
 <ContextMenu Id="menu1" Template="dark" OnAppearing="OnAppearingMenu1">
@@ -137,10 +140,20 @@
     <Item Id="menu6-item2" OnClick="OnClick"><ItemChild>Item 2</ItemChild></Item>
 </ContextMenu>
 
+<ContextMenu Id="menu7" AutoHide="false"> 
+    <Item Id="menu7-item1">Item 1</Item>
+    <Item Id="menu7-item2">Item 2</Item>
+</ContextMenu>
+
 <div>
     <button id="showMenuBtn" @onclick="ShowMenuBtnOnClick">Show menu1 in 300x300 using handler</button>
     <button id="showNoAutoCloseBtn" @onclick="ShowNoAutoCloseBtnOnClick">Show menu1 in 300x300 using handler</button>
     <button id="showAndHideMenuBtn" @onclick="ShowAndHideMenuBtnClick">Show menu1 in 300x300 using handler and hide after 2 seconds</button>
+</div>
+
+<div>
+    <button id="determineIfMenu7IsShownbtn" @onclick="DetermineIfMenu7IsShown">Determine if menu7 is shown</button>
+    <p id="menu7-isShownResult">@IsMenu7Shown</p>
 </div>
 
 <hr />
@@ -172,12 +185,12 @@
     </div>
 </ContextMenuTrigger>
 
-
 <NavLink href="/TodoList">Go to Todo List</NavLink>
 <div id="app_loaded"></div>
 
 @code{
     private bool menu1Autoclose = true;
+
     protected async Task ShowMenuBtnOnClick()
     {
         await blazorContextMenuService.ShowMenu("menu1", 300, 300);
@@ -200,6 +213,14 @@
     protected string Summaries { get; set; }
 
     protected Animation Animation { get; set; }
+
+    protected string IsMenu7Shown { get; set; } = bool.FalseString;
+
+    protected async Task DetermineIfMenu7IsShown() 
+    {
+        var isShown = await blazorContextMenuService.IsMenuShown("menu7");
+        IsMenu7Shown = isShown.ToString();
+    }
 
     async Task FetchDataClick(ItemClickEventArgs e)
     {

--- a/Tests/BlazorContextMenu.TestsCommon/CommonTests/TestAppIndexTests.cs
+++ b/Tests/BlazorContextMenu.TestsCommon/CommonTests/TestAppIndexTests.cs
@@ -429,5 +429,38 @@ namespace BlazorContextMenu.E2ETests.Tests
             var display = menuElement.GetCssValue("display");
             Assert.Equal(expectedDisplay, display);
         }
+
+        [Fact]
+        public void Menu7_InitialState_MenuIsShownReturnsFalse()
+        {
+            //Arrange
+            var expectedDisplay = bool.FalseString;
+
+            //Act
+            var determineIfMenu7IsShownbtn = Browser.FindElement(By.Id("determineIfMenu7IsShownbtn"));
+            determineIfMenu7IsShownbtn.Click();
+
+            //Assert
+            var menuElement = Browser.FindElement(By.Id("menu7-isShownResult"));
+            var display = menuElement.GetAttribute("text");
+            Assert.Equal(expectedDisplay, display);
+        }
+
+        [Fact]
+        public async Task Menu7_TriggerMenu_MenuIsShownReturnsTrue()
+        {
+            //Arrange
+            var expectedDisplay = bool.TrueString;
+
+            //Act
+            await OpenContextMenuAt("menu7", MouseButtonTrigger.Left);
+            var determineIfMenu7IsShownbtn = Browser.FindElement(By.Id("determineIfMenu7IsShownbtn"));
+            determineIfMenu7IsShownbtn.Click();
+
+            //Assert
+            var menuElement = Browser.FindElement(By.Id("menu7-isShownResult"));
+            var display = menuElement.GetAttribute("text");
+            Assert.Equal(expectedDisplay, display);
+        }
     }
 }


### PR DESCRIPTION
## Overview
This came about because I have a button that shows the Menu via a button click.

`<button @onclick="ToggleMenu">Show Menu</button>`

with

```
private async Task ToggleMenu()
{
  if (menuIsShown)
  {
      await BlazorContextMenuService.HideMenu("menu");
  }
  else
  {
      await BlazorContextMenuService.ShowMenu("menu", (int) mouseEventArgs.ClientX, (int) mouseEventArgs.ClientY);
  }
  menuIsShown = !menuIsShown;
}  
```

My local variable `menuIsShown` cannot be used because the Menu is set to AutoHide. I need another way of determining if the menu is shown. E.g.,

```
if (BlazorContextMenuService.IsMenuShown("menu"))
{
    await BlazorContextMenuService.HideMenu("menu");
}
else
{
    await BlazorContextMenuService.ShowMenu("menu", (int) mouseEventArgs.ClientX, mouseEventArgs.ClientY);
}
```

## Tests
I could not get the tests to run but I have attempted to write some.
