### PR TITLE
Use shorthand onclick to ensure async-ness

### DIFF
--- a/BlazorContextMenu/Components/Item.razor
+++ b/BlazorContextMenu/Components/Item.razor
@@ -6,7 +6,7 @@
 
 <li @attributes="Attributes"
     id="@Id"
-    @onclick="@((e) => OnClickInternal(e))"
+    @onclick="OnClickInternal"
     class="@("blazor-context-menu__item " + ClassCalc)"
     style="@(Visible ? "display:block;" : "display:none;")"
     itemEnabled="@Enabled.ToString().ToLower()"


### PR DESCRIPTION
I don't think the onclick method was executing async.

It should have been `onclick="@(async () => await Delete(id))"` however, we can now use the short hand way as shown in PR according to https://stackoverflow.com/questions/60487996/anonymous-methods-3-different-ways-async/60488286#60488286