### PR TITLE
Correcting TypeError in Submenu Mouseover Events

### DIFF
--- a/BlazorContextMenu/wwwroot/blazorContextMenu.js
+++ b/BlazorContextMenu/wwwroot/blazorContextMenu.js
@@ -275,7 +275,7 @@ var blazorContextMenu = function (blazorContextMenu) {
                         blazorContextMenu.Hide(subMenu.id);
                     }
 
-                    i = currentMenuList.childNodes.length;
+                    i = currentMenuList.children.length;
                     while (i--) {
                         var child = currentMenuList.children[i];
                         if (child == currentItemElement) continue;
@@ -283,9 +283,9 @@ var blazorContextMenu = function (blazorContextMenu) {
                     }
                 };
 
-                var i = currentMenuList.childNodes.length;
+                var i = currentMenuList.children.length;
                 while (i--) {
-                    var child = currentMenuList.childNodes[i];
+                    var child = currentMenuList.children[i];
                     if (child == currentItemElement) continue;
 
                     child.addEventListener("mouseover", closeSubMenus);


### PR DESCRIPTION
**Description:**
Issue #155  involved a TypeError on mouseover events in submenu items, due to currentMenuList.childNodes including non-element nodes like text and comments that don't support event methods.

**Solution Implemented:**
I switched from currentMenuList.childNodes to currentMenuList.children in our code, which targets only HTML element nodes. This effectively resolves the JavaScript error by ensuring event listeners are applied solely to suitable elements. Notably, Blazor Server frequently inserts <!--!--> comment nodes in HTML, which were being mishandled and caused the initial problem.

